### PR TITLE
Add em-dash and guillemets to popup characters

### DIFF
--- a/app/src/main/res/xml/kbd_symbols.xml
+++ b/app/src/main/res/xml/kbd_symbols.xml
@@ -132,7 +132,8 @@
         <Key
             android:codes="45"
             android:keyWidth="9%p"
-            android:keyLabel="-" />
+            android:keyLabel="-"
+            android:popupCharacters="—" />
         <Key
             android:codes="43"
             android:keyWidth="9%p"
@@ -177,7 +178,8 @@
         <Key
             android:codes="34"
             android:keyWidth="9%p"
-            android:keyLabel="&quot;" />
+            android:keyLabel="&quot;"
+            android:popupCharacters="«»" />
         <Key
             android:codes="39"
             android:keyWidth="9%p"


### PR DESCRIPTION
Added the em-dash (—) as a popup character for the hyphen (-) key, and guillemets («») as a popup character for the quote (") key in the kbd_symbols.xml file. This addition significantly improves typography support for editing the Karakalpak Wikipedia and writing academic texts.